### PR TITLE
Zip both folders together

### DIFF
--- a/automation/MakeZips.ts
+++ b/automation/MakeZips.ts
@@ -35,18 +35,18 @@ export async function MakeZips() {
     console.log('Starting Zip process');
 
     console.log("Starting Block zip process");
-    const { stdout1, stderr1 } = await exec('zip', ['-1jr', blockZipPath, blocksFolder]);
-    console.log(stdout1, stderr1);
+    var { stdout, stderr } = await exec('zip', ['-1jr', blockZipPath, blocksFolder]);
+    console.log(stdout, stderr);
     console.log('Zipped blocks');
 
     console.log("Starting Chainstate zip process");
-    const { stdout2, stderr2 } = await exec('zip', ['-1jr', chainstateZipPath, chainstateFolder]);
-    console.log(stdout2, stderr2);
+    var { stdout, stderr } = await exec('zip', ['-1jr', chainstateZipPath, chainstateFolder]);
+    console.log(stdout, stderr);
     console.log('Zipped chainstate');
 
     console.log("Starting zip for all files");
-    const { stdout3, stderr3 } = await exec('zip', ['-1jr', networkZipPath, blockZipPath, chainstateZipPath]);
-    console.log(stdout3, stderr3);
+    var { stdout, stderr } = await exec('zip', ['-1jr', networkZipPath, blockZipPath, chainstateZipPath]);
+    console.log(stdout, stderr);
     console.log('Zipped all files');
 
     const reader = fs.createReadStream(networkZipPath);

--- a/automation/MakeZips.ts
+++ b/automation/MakeZips.ts
@@ -37,6 +37,11 @@ const s3Stream = S3Stream(s3);
 export async function MakeZips() {
     console.log('Starting Zip process');
 
+    console.log("creating snapshot folder", temporaryDiviSnapshotFolderPath);
+    var { stdout, stderr } = await exec('mkdir', [temporaryDiviSnapshotFolderPath]);
+    console.log(stdout, stderr);
+    console.log("created snapshot folder");
+
     console.log("Starting Block zip process");
     var { stdout, stderr } = await exec('zip', ['-1jr', blockZipPath, blocksFolder]);
     console.log(stdout, stderr);

--- a/automation/MakeZips.ts
+++ b/automation/MakeZips.ts
@@ -17,7 +17,7 @@ export const chainstateZipFileName = `chainstate-snapshot.zip`;
 export const chainstateZipPath = join(cwd, chainstateZipFileName);
 
 export const network = process.env.NETWORK || 'testnet';
-export const snapshotZipFileName = Number(new Date()) + `-${network}-snapshot.zip`;
+export const snapshotZipFileName = `divi-snapshots-${Number(new Date())}.zip`;
 export const snapshotZipFilePath = join(cwd, snapshotZipFileName);
 
 export const temporaryDiviSnapshotFolderPath = "/divi-snapshot";

--- a/automation/MakeZips.ts
+++ b/automation/MakeZips.ts
@@ -17,7 +17,7 @@ export const chainstateZipFileName = `chainstate-snapshot.zip`;
 export const chainstateZipPath = join(cwd, chainstateZipFileName);
 
 export const network = process.env.NETWORK || 'testnet';
-export const snapshotZipFileName = `divi-snapshots-${Number(new Date())}.zip`;
+export const snapshotZipFileName = `${Number(new Date())}-${network}-snapshot.zip`;
 export const snapshotZipFilePath = join(cwd, snapshotZipFileName);
 
 export const temporaryDiviSnapshotFolderPath = "/divi-snapshot";

--- a/automation/MakeZips.ts
+++ b/automation/MakeZips.ts
@@ -20,6 +20,8 @@ export const network = process.env.NETWORK || 'testnet';
 export const snapshotZipFileName = Number(new Date()) + `-${network}-snapshot.zip`;
 export const snapshotZipFilePath = join(cwd, snapshotZipFileName);
 
+export const temporaryDiviSnapshotFolderPath = "/divi-snapshot";
+
 export const endpoint = 'https://nyc3.digitaloceanspaces.com';
 export const accessKeyId = process.env.KEY || '';
 export const secretAccessKey = process.env.SECRET || '';

--- a/automation/MakeZips.ts
+++ b/automation/MakeZips.ts
@@ -18,7 +18,7 @@ export const chainstateZipPath = join(cwd, chainstateZipFileName);
 
 export const network = process.env.NETWORK || 'testnet';
 export const snapshotZipFileName = Number(new Date()) + `-${network}-snapshot.zip`;
-export const networkZipPath = join(cwd, snapshotZipFileName);
+export const snapshotZipFilePath = join(cwd, snapshotZipFileName);
 
 export const endpoint = 'https://nyc3.digitaloceanspaces.com';
 export const accessKeyId = process.env.KEY || '';
@@ -46,11 +46,11 @@ export async function MakeZips() {
     console.log('Zipped chainstate');
 
     console.log("Starting zip for all files");
-    var { stdout, stderr } = await exec('zip', ['-1jr', networkZipPath, blockZipPath, chainstateZipPath]);
+    var { stdout, stderr } = await exec('zip', ['-1jr', snapshotZipFilePath, blockZipPath, chainstateZipPath]);
     console.log(stdout, stderr);
     console.log('Zipped all files');
 
-    const reader = fs.createReadStream(networkZipPath);
+    const reader = fs.createReadStream(snapshotZipFilePath);
     const uploader = s3Stream.upload(
         {
             ACL: 'public-read',
@@ -74,7 +74,7 @@ export async function MakeZips() {
 
         fs.unlinkSync(blockZipPath);
         fs.unlinkSync(chainstateZipPath);
-        fs.unlinkSync(networkZipPath);
+        fs.unlinkSync(snapshotZipFilePath);
 
         console.log('Removed temporary zip files');
     });

--- a/automation/MakeZips.ts
+++ b/automation/MakeZips.ts
@@ -17,8 +17,8 @@ export const chainstateZipFileName = `chainstate-snapshot.zip`;
 export const chainstateZipPath = join(cwd, chainstateZipFileName);
 
 export const network = process.env.NETWORK || 'testnet';
-export const networkZipFileName = Number(new Date()) + `-${network}-snapshot.zip`;
-export const networkZipPath = join(cwd, networkZipFileName);
+export const snapshotZipFileName = Number(new Date()) + `-${network}-snapshot.zip`;
+export const networkZipPath = join(cwd, snapshotZipFileName);
 
 export const endpoint = 'https://nyc3.digitaloceanspaces.com';
 export const accessKeyId = process.env.KEY || '';
@@ -56,7 +56,7 @@ export async function MakeZips() {
             ACL: 'public-read',
             ContentType: 'application/zip',
             Bucket: 'divi-snapshots',
-            Key: networkZipFileName,
+            Key: snapshotZipFileName,
         },
     );
 

--- a/automation/MakeZips.ts
+++ b/automation/MakeZips.ts
@@ -42,21 +42,29 @@ export async function MakeZips() {
     console.log(stdout, stderr);
     console.log("created snapshot folder");
 
-    console.log("Starting Block zip process");
-    var { stdout, stderr } = await exec('zip', ['-1jr', blockZipPath, blocksFolder]);
+    console.log("copying blocks into snapshot folder");
+    var { stdout, stderr } = await exec('cp', ['-a', blocksFolder, temporaryDiviSnapshotFolderPath+"/blocks"]);
     console.log(stdout, stderr);
     console.log('Zipped blocks');
 
-    console.log("Starting Chainstate zip process");
-    var { stdout, stderr } = await exec('zip', ['-1jr', chainstateZipPath, chainstateFolder]);
+    console.log("copying chainstate into snapshot folder");
+    var { stdout, stderr } = await exec('cp', ['-a', chainstateFolder, temporaryDiviSnapshotFolderPath+"/chainstate"]);
     console.log(stdout, stderr);
     console.log('Zipped chainstate');
 
-    console.log("Starting zip for all files");
-    var { stdout, stderr } = await exec('zip', ['-1jr', snapshotZipFilePath, blockZipPath, chainstateZipPath]);
+    console.log("Zipping snapshot folder");
+    var { stdout, stderr } = await exec('zip', ['-1r', snapshotZipFileName, temporaryDiviSnapshotFolderPath]);
     console.log(stdout, stderr);
-    console.log('Zipped all files');
+    console.log('Zipped');
 
+    console.log("Deleting temporary snapshot folder");
+    var { stdout, stderr } = await exec('rm', ['-r', temporaryDiviSnapshotFolderPath]);
+    console.log(stdout, stderr);
+    console.log('Deleted');
+
+    console.log('Zip process completed');
+
+    console.log('Uploading');
     const reader = fs.createReadStream(snapshotZipFilePath);
     const uploader = s3Stream.upload(
         {
@@ -79,8 +87,6 @@ export async function MakeZips() {
         console.log(data);
         console.log('Snapshot taken successfully');
 
-        fs.unlinkSync(blockZipPath);
-        fs.unlinkSync(chainstateZipPath);
         fs.unlinkSync(snapshotZipFilePath);
 
         console.log('Removed temporary zip files');

--- a/automation/MakeZips.ts
+++ b/automation/MakeZips.ts
@@ -7,11 +7,12 @@ const exec = require('execa');
 
 export const cwd = process.cwd();
 export const folder = join(cwd, '..', '.divi');
+
 export const blocksFolder = join(folder, 'blocks');
-export const chainstateFolder = join(folder, 'chainstate');
 export const blockZipFileName = `blocks-snapshot.zip`;
 export const blockZipPath = join(cwd, blockZipFileName);
 
+export const chainstateFolder = join(folder, 'chainstate');
 export const chainstateZipFileName = `chainstate-snapshot.zip`;
 export const chainstateZipPath = join(cwd, chainstateZipFileName);
 

--- a/automation/MakeZips.ts
+++ b/automation/MakeZips.ts
@@ -34,19 +34,19 @@ const s3Stream = S3Stream(s3);
 export async function MakeZips() {
     console.log('Starting Zip process');
 
+    console.log("Starting Block zip process");
     const { stdout1, stderr1 } = await exec('zip', ['-1jr', blockZipPath, blocksFolder]);
     console.log(stdout1, stderr1);
-
     console.log('Zipped blocks');
 
+    console.log("Starting Chainstate zip process");
     const { stdout2, stderr2 } = await exec('zip', ['-1jr', chainstateZipPath, chainstateFolder]);
     console.log(stdout2, stderr2);
-
     console.log('Zipped chainstate');
 
+    console.log("Starting zip for all files");
     const { stdout3, stderr3 } = await exec('zip', ['-1jr', networkZipPath, blockZipPath, chainstateZipPath]);
     console.log(stdout3, stderr3);
-
     console.log('Zipped all files');
 
     const reader = fs.createReadStream(networkZipPath);


### PR DESCRIPTION
Instead of zipping chainstate, then zipping blocks, and zipping those two together. 
Zip just one folder containing both chainstate and blocks.

Also, fix the logging of non-existent variables.